### PR TITLE
Sarah afiya/issue 19/improve api detection for special params cases

### DIFF
--- a/documentation_quality_analysis/analyze_library/doc_parser/doc_parser.py
+++ b/documentation_quality_analysis/analyze_library/doc_parser/doc_parser.py
@@ -127,7 +127,7 @@ def get_all_webpages(doc_home: str, max_depth: int) -> List[DocPage]:
 
 
 def get_functions_and_classes_from_doc_api_ref(doc_pages: List[DocPage]) -> List[Signature]:
-    api_ref_keywords = ['api', 'reference']
+    api_ref_keywords = ['api', 'reference', 'collections']
     signatures: List[Signature] = []
     for page in doc_pages:
         if any(word in page.url for word in api_ref_keywords):

--- a/tests/documentation_quality_analysis/analyze_library/doc_parser/test.html
+++ b/tests/documentation_quality_analysis/analyze_library/doc_parser/test.html
@@ -121,6 +121,33 @@
                             </dd>
                         </dl>
 
+                        <dl class="py method">
+                        <dt class="sig sig-object py" id="pandas.Series.set_axis">
+                        <span class="sig-prename descclassname"><span class="pre">Series.</span></span><span class="sig-name descname"><span class="pre">set_axis</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">labels</span></span></em>, <em class="sig-param"><span class="o"><span class="pre">*</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">axis</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">0</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">copy</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span><a class="reference external" href="https://github.com/pandas-dev/pandas/blob/v2.1.0/pandas/core/series.py#L4929-L4962"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#pandas.Series.set_axis" title="Permalink to this definition">#</a></dt>
+                        <dd><p>Assign desired index to given axis.</p>
+                        <p>Indexes for row labels can be changed by assigning
+                        a list-like or Index.</p>
+                        </dl>
+
+                        <dl class="py method">
+                        <dt class="sig sig-object py" id="pandas.Series.ffill">
+                        <span class="sig-prename descclassname"><span class="pre">Series.</span></span><span class="sig-name descname"><span class="pre">ffill</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="o"><span class="pre">*</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">axis</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">inplace</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">False</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">limit</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">downcast</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">_NoDefault.no_default</span></span></em><span class="sig-paren">)</span><a class="reference external" href="https://github.com/pandas-dev/pandas/blob/v2.1.0/pandas/core/generic.py#L7342-L7433"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#pandas.Series.ffill" title="Permalink to this definition">#</a></dt>
+                        </dl>
+
+                        <dl class="py method">
+                        <dt class="sig sig-object py" id="pandas.Series.spparam1">
+                        <span class="sig-prename descclassname"><span class="pre">Series.</span></span><span class="sig-name descname"><span class="pre">spparam1</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="o"><span class="pre">a</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">axis</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">inplace</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">False</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">limit</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">downcast</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">_NoDefault.no_default</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">/</span></span></em><span class="sig-paren">)</span><a class="reference external" href="https://github.com/pandas-dev/pandas/blob/v2.1.0/pandas/core/generic.py#L7342-L7433"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#pandas.Series.ffill" title="Permalink to this definition">#</a></dt>
+                        </dl>
+
+                        <dl class="py method">
+                        <dt class="sig sig-object py" id="pandas.Series.spparam2">
+                        <span class="sig-prename descclassname"><span class="pre">Series.</span></span><span class="sig-name descname"><span class="pre">spparam2</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="o"><span class="pre">a</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">axis</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">inplace</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">False</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">limit</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">/</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">downcast</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">_NoDefault.no_default</span></span></em><span class="sig-paren">)</span><a class="reference external" href="https://github.com/pandas-dev/pandas/blob/v2.1.0/pandas/core/generic.py#L7342-L7433"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#pandas.Series.ffill" title="Permalink to this definition">#</a></dt>
+                        </dl>
+
+
+
+
+
                     </section>
 
                 </section>

--- a/tests/documentation_quality_analysis/analyze_library/doc_parser/test_doc_parser.py
+++ b/tests/documentation_quality_analysis/analyze_library/doc_parser/test_doc_parser.py
@@ -18,11 +18,13 @@ class TestDocParser(TestCase):
         methods = [x.fully_qualified_name for x in doc_apis if type(x) == MethodSignature]
         classes = [x.fully_qualified_name for x in doc_apis if type(x) == ClassConstructorSignature]
 
-        expected_methods = ['requests.request', 'requests.Session.close', 'requests.Session.send']
+        expected_methods = ['requests.request', 'requests.Session.close', 'requests.Session.send',
+                            'pandas.Series.set_axis', 'pandas.Series.ffill', 'pandas.Series.spparam1',
+                            'pandas.Series.spparam2']
         expected_classes = ['x.requests.Request', 'requests.Session', 'requests.RequestException']
 
-        self.assertEqual(len(doc_apis), 6)
-        self.assertEqual(len(methods), 3)
+        self.assertEqual(len(doc_apis), 9)
+        self.assertEqual(len(methods), 7)
         self.assertEqual(len(classes), 3)
         self.assertEqual(expected_methods, methods)
         self.assertEqual(expected_classes, classes)


### PR DESCRIPTION
Looked for special parameters like '*' or '/' and removed them to parse the statements properly. as.parse cannot parse those special params.

examples: 
- asterisk_usage(either, *, keyword_only) 
- slash_usage(positional_only, /, either)
- Series.fill(*, axis=None, inplace=False, limit=None)